### PR TITLE
Adding Helper Method to convert Option Array into String Array

### DIFF
--- a/Cultured/ViewModels/ViewModel.swift
+++ b/Cultured/ViewModels/ViewModel.swift
@@ -1176,9 +1176,10 @@ class ViewModel: ObservableObject {
     
     func createNewConnections(connection: Connections) {
         let connectionsReference = db.collection("GAMES").document(connection.title)
+        let answerKeyDict = convertAnswerKeyToStringDict(answerKey: connection.answer_key)
         connectionsReference.setData(
             ["title": connection.title,
-             "answerKey": connection.answer_key
+             "answerKey": answerKeyDict
             ]) { error in
                 if let error = error {
                     print("Error writing game document: \(error.localizedDescription)")
@@ -1304,6 +1305,15 @@ class ViewModel: ObservableObject {
                 }
             }
         }
+    }
+    
+    func convertAnswerKeyToStringDict(answerKey: [String: [Connections.Option]]) -> [String: [String]] {
+        var stringDict: [String: [String]] = [:]
+        for (key, options) in answerKey {
+            let strings = options.map { $0.content }
+            stringDict[key] = strings
+        }
+        return stringDict
     }
     
     /*-------------------------------------------------------------------------------------------------*/


### PR DESCRIPTION
- simply added a helper method that converts from [String: [Connections.Option]]) to [String: [String]] so that it can be used in createNewConnections(connection: Connections) to populate the firebase easier
- unit testing stayed same